### PR TITLE
fix(ui): add black text color for background dropdown in light mode

### DIFF
--- a/src/components/BackgroundSelectorCompact.astro
+++ b/src/components/BackgroundSelectorCompact.astro
@@ -22,7 +22,7 @@ const t = useTranslations(Astro.currentLocale as 'es' | 'en' ?? 'es');
   </button>
 
   <div
-    class="absolute right-0 top-full mt-2 w-40 bg-white dark:bg-gray-900 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 border border-gray-200 dark:border-gray-700"
+    class="absolute right-0 top-full mt-2 w-40 bg-white text-black dark:bg-gray-900 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 border border-gray-200 dark:border-gray-700"
   >
     <div class="py-2">
       <button 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -146,7 +146,7 @@ const navLinks = [
                           langCode as any,
                           currentPathWithoutLocale
                         )}
-                        class="block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors dark:text-white"
+                        class="block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors tex-black text-black dark:text-white"
                       >
                         {langName}
                       </a>


### PR DESCRIPTION
## 📄 Description  
Fixed a **visibility issue** in the background effects dropdown where text was hard to read in **light mode**.  
This update applies a **black text color** when the light theme is active, ensuring proper contrast and readability.  

---

## 📝 Change summary  
- Added conditional styling for text color in the background dropdown  
- Set text to **black** in light mode for improved readability  
- Maintained **white text** for dark mode consistency  
- Verified color contrast meets accessibility standards  

---

## 📝 Types of changes  
- [x] 🐛 Bug fix  
- [ ] 🚨 Breaking change  
- [ ] ✨ New feature  
- [ ] 🧹 Chore  
- [ ] ⏫ Version upgrade  
- [ ] 📝 Documentation  

---

## 🧪 How to test  
1. Switch the site theme to **light mode**  
2. Open the **background effects dropdown**  
3. Verify that all text items are clearly visible (black text on light background)  
4. Switch back to **dark mode** and ensure white text is still applied correctly  

---

## 📸 Screenshots  

### Before  
<img width="1906" height="417" alt="image" src="https://github.com/user-attachments/assets/4d7d3fb5-efb2-4635-8440-b73e8b155152" />
<img width="1904" height="416" alt="image" src="https://github.com/user-attachments/assets/f6e182dc-0ce1-404e-b904-3cccf7b8501a" />


### After  
<img width="1906" height="418" alt="image" src="https://github.com/user-attachments/assets/041ae094-6fd9-407a-b459-df228ee4b0a4" />
<img width="1906" height="416" alt="image" src="https://github.com/user-attachments/assets/c0152ad6-9b9a-4502-8599-e94d558119c7" />


---
